### PR TITLE
some fixes

### DIFF
--- a/sa-daily-report.rb
+++ b/sa-daily-report.rb
@@ -59,6 +59,8 @@ require 'date'
 require 'net/smtp'
 require 'mail'
 require 'mail/parsers/content_type_parser'
+## this is to check the encoding (https://github.com/brianmario/charlock_holmes)
+require 'charlock_holmes'
 
 class Sorter
   
@@ -200,6 +202,11 @@ class Spam
   end
 
   def feed(line)
+
+### check every line for encoding to prevent "invalid byte sequence in UTF-8" errors
+    detection = CharlockHolmes::EncodingDetector.detect(content)
+    line = CharlockHolmes::Converter.convert line, detection[:encoding], 'UTF-8'
+
     case line
     when re_from
       @from = Mail::Encodings.unquote_and_convert_to( line, 'utf-8' )

--- a/sa-daily-report.rb
+++ b/sa-daily-report.rb
@@ -58,7 +58,7 @@ require 'zlib'
 require 'date'
 require 'net/smtp'
 require 'mail'
-require "mail/parsers/content_type_parser"
+require 'mail/parsers/content_type_parser'
 
 class Sorter
   


### PR DESCRIPTION
decode encoded subject and email names for example cyrillic ones before sending the report
fix to get rid of warning "attempt to close unfinished zstream; reset forced."